### PR TITLE
fix for gallery row alignment

### DIFF
--- a/source/scss/template-main.scss
+++ b/source/scss/template-main.scss
@@ -176,7 +176,8 @@
       clear: both;
       .campaign-thumbnail {
         width: 33.3333%;
-        float: left;
+        display: inline-block;
+        vertical-align: top;
       }
     }
   }


### PR DESCRIPTION
Fix for the main page gallery alignment - thumbnail titles vary in length