### PR TITLE
more post launch revisions

### DIFF
--- a/source/js/controllers.js
+++ b/source/js/controllers.js
@@ -19,8 +19,18 @@ landingPageGallery.controller('mainCtrl', ['$routeParams', 'appdata', '$filter',
     templatesCurrent = templatesCurrent.concat(template);
   }
 
+  // Remove duplicates
+  topics = $filter('unique')(topics,'toString()');
+  types = $filter('unique')(types,'toString()');
+  templatesCurrent = $filter('unique')(templatesCurrent,'id');
+  // Sort by alpha ascending
+  topics = $filter('orderBy')(topics,'toString()');
+  types = $filter('orderBy')(types,'toString()');
+  templatesCurrent = $filter('orderBy')(templatesCurrent,'title');
+
   // Pass campaigns data to controllerAs for use on the front
   this.campaigns = campaigns;
+
   this.topics = topics;
   this.types = types;
   this.templates = templatesCurrent;

--- a/source/js/services.js
+++ b/source/js/services.js
@@ -14,10 +14,10 @@ landingPageGallery.factory('fetchData', function($q, $http, $rootScope) {
         function success(response) {
           $rootScope.dataFetched = true; console.log('Data Fetched');
           cache = response.data;
-          var c = cache.campaigns;
-          for (var i=0; i < c.length; i++) {
-            c[i].shortCode = MD5(c[i].id).substring(0, 6)
+          for (var i=0; i < cache.campaigns.length; i++) {
+            cache.campaigns[i].shortCode = MD5(cache.campaigns[i].id).substring(0, 6)
           }
+          cache.campaigns = shuffleArray(cache.campaigns);
           $rootScope.$watch('splashFinished', function(){
             if($rootScope.splashFinished){
               console.log('Animation Complete');

--- a/source/partials/debug.html
+++ b/source/partials/debug.html
@@ -13,6 +13,7 @@
 <div ng-repeat="c in debug.campaigns">
   <h2>{{c.title}}</h2>
   <h3>{{c.id}}</h3>
+  <h4>{{c.shortCode}}</h4>
   <h4>{{c.url}}</h4>
   <p>{{c.topic}}</p>
   <p>{{c.type}}</p>

--- a/source/partials/detail.html
+++ b/source/partials/detail.html
@@ -13,7 +13,7 @@
         <img src="http://web-q-hospital.prod.ehc.com/global/webq/landing-page-gallery/screenshots/{{detail.campaign.id}}-d-lg.png" />
       </section>
       <section id="template-detail">
-        <p>{{detail.renderHTML(detail.template.description)}}</p>
+        <div ng-bind-html="detail.renderHTML(detail.template.description)"></div>
         <h4>Features</h4>
         <ul>
           <li ng-repeat="f in detail.template.features">{{f}}</li>

--- a/source/partials/main.html
+++ b/source/partials/main.html
@@ -21,19 +21,19 @@
           <div class="filter-dropdown">
             <select ng-model="main.filters.topic" ng-change="main.filterResults()">
               <option value="">Topic</option>
-              <option ng-repeat="t in main.topics | unique track by $index" value="{{t}}">{{t}}</option>
+              <option ng-repeat="t in main.topics track by $index" value="{{t}}">{{t}}</option>
             </select>
           </div>
           <div class="filter-dropdown">
             <select ng-model="main.filters.type" ng-change="main.filterResults()">
               <option value="">Type</option>
-              <option ng-repeat="t in main.types | unique track by $index" value="{{t}}">{{t}}</option>
+              <option ng-repeat="t in main.types track by $index" value="{{t}}">{{t}}</option>
             </select>
           </div>
           <div class="filter-dropdown">
             <select ng-model="main.filters.templateId" ng-change="main.filterResults()">
               <option value="">Template</option>
-              <option ng-repeat="t in main.templates | unique:'id'" value="{{t.id}}">{{t.title}}</option>
+              <option ng-repeat="t in main.templates" value="{{t.id}}">{{t.title}}</option>
             </select>
           </div>
           <div class="clear-search">


### PR DESCRIPTION
- shuffle campaigns array to avoid having all premium templates at the top
- add more flexibility to the description section
- sort topic/type/template selection by alpha order